### PR TITLE
Ensure pod is scheduled on a control-plane node

### DIFF
--- a/etcdbk.yaml
+++ b/etcdbk.yaml
@@ -24,6 +24,14 @@ spec:
       storage: 1Gi
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcdbk
+  namespace: etcdbk
+
+---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -41,13 +49,13 @@ metadata:
   name: etcdbk
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: etcdbk
   namespace: etcdbk
 roleRef:
   kind: ClusterRole 
   name: etcdbk
   apiGroup: rbac.authorization.k8s.io
-  
+
 ---
 
 apiVersion: batch/v1
@@ -90,6 +98,7 @@ spec:
             - mountPath: /data
               name: data-dir
           restartPolicy: OnFailure
+          serviceAccountName: etcdbk
           tolerations:
           - effect: NoSchedule
             operator: Exists

--- a/etcdbk.yaml
+++ b/etcdbk.yaml
@@ -65,13 +65,20 @@ spec:
     spec:
       template:
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
           containers:
           - env:
             - name: TZ
               value: "Asia/Kuala_Lumpur"
             name: etcdbk
             image: nexus.internal:7082/repository/containers/etcdbk:1.0.0
-            imagePullPolicy: IfNotPresent
+            imagePullPolicy: Always
             resources:
               requests:
                 cpu: 100m
@@ -83,6 +90,11 @@ spec:
             - mountPath: /data
               name: data-dir
           restartPolicy: OnFailure
+          tolerations:
+          - effect: NoSchedule
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
           volumes:
           - hostPath:
               path: /etc/kubernetes/pki/etcd


### PR DESCRIPTION
Added a nodeAffinity to manifest to ensure all pods with be scheduled onto a control-plane node. Also added tolerations to allow pods to be scheduled tainted control-planes.  Updated imagePullPolicy to Always,  will only download the images if current image does not match the digest on the registry.

Please review and test.